### PR TITLE
Disable trailing whitespace rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Layout/MultilineMethodCallIndentation:
 Layout/EmptyLinesAroundAccessModifier:
   EnforcedStyle: only_before
 
+Layout/TrailingWhitespace:
+  Enabled: false
+
 Lint/SuppressedException:
   Exclude:
     - "test/**/*"


### PR DESCRIPTION
Having PRs fail due to trailing whitespace does not hold any value and only annoys contributors.